### PR TITLE
fix: restore green CI (revert js-yaml to 4.x, pin prettier)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.5.1",
             "license": "MIT",
             "dependencies": {
-                "js-yaml": "^5.2.0"
+                "js-yaml": "^4.3.0"
             },
             "bin": {
                 "symflow": "dist/cli.js"
@@ -22,7 +22,7 @@
                 "@xyflow/react": "^12.10.2",
                 "eslint": "^10.2.1",
                 "eslint-config-prettier": "^10.1.8",
-                "prettier": "^3.8.3",
+                "prettier": "3.9.4",
                 "tsup": "^8.3.5",
                 "typescript": "^6.0.3",
                 "vitest": "^4.1.4"
@@ -2714,9 +2714,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
-            "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "funding": [
                 {
                     "type": "github",
@@ -2732,7 +2732,7 @@
                 "argparse": "^2.0.1"
             },
             "bin": {
-                "js-yaml": "bin/js-yaml.mjs"
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         }
     },
     "dependencies": {
-        "js-yaml": "^5.2.0"
+        "js-yaml": "^4.3.0"
     },
     "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -140,7 +140,7 @@
         "@xyflow/react": "^12.10.2",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
-        "prettier": "^3.8.3",
+        "prettier": "3.9.4",
         "tsup": "^8.3.5",
         "typescript": "^6.0.3",
         "vitest": "^4.1.4"

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -75,13 +75,7 @@ export interface TransitionResult {
 }
 
 export type WorkflowEventType =
-    | "guard"
-    | "leave"
-    | "transition"
-    | "enter"
-    | "entered"
-    | "completed"
-    | "announce";
+    "guard" | "leave" | "transition" | "enter" | "entered" | "completed" | "announce";
 
 export interface WorkflowEvent {
     type: WorkflowEventType;


### PR DESCRIPTION
## Summary

`main` was broken in two independent ways. CI only surfaced the first because `format:check` failed and cancelled the run before `typecheck`/`test` could run.

1. **js-yaml 5.2.0 (#62)** is a full API rewrite that removes `Type`, `DEFAULT_SCHEMA`, and `Schema.extend()` — exactly what `src/yaml/import.ts` uses for the Symfony `!php/const` / `!php/enum` custom tags. It broke `typecheck` and the yaml/php-enum/event test suites, and `@types/js-yaml` was left at 4.x, mismatching the 5.x runtime. Reverted to `^4.3.0` until a proper 5.x migration is done.

2. **prettier `^3.8.3`** floats to 3.9.4 on a fresh `npm ci`. Prettier 3.9 collapses a short union type onto one line where 3.8 kept the leading-`|` multiline form, so `format:check` failed in CI while passing on cached 3.8.x installs. Pinned exact `3.9.4` so local and CI format identically, and reformatted `src/engine/types.ts`.

## Verification

Full pipeline green locally: **lint · format:check · typecheck · 246 tests · build**. (246 tests run now vs 184 previously — the 4 yaml-dependent suites had been erroring on import.)

## Follow-up

A real migration to the js-yaml 5.x API (`defineScalarTag` / `Schema`) should be tracked separately so dependabot doesn't silently re-break the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)